### PR TITLE
RenderType is now specified when data are flattened/saved (usefull to support Print or View restriction).

### DIFF
--- a/MRGPDFKit/Model/MRGPDFKitDocument.h
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.h
@@ -11,6 +11,12 @@
 @class MRGPDFKitDictionary;
 @class MRGPDFKitForm;
 
+typedef NS_ENUM(NSUInteger, MRGPDFKitDocumentRenderType) {
+    MRGPDFKitDocumentRenderTypePrint = 0,
+    MRGPDFKitDocumentRenderTypeView,
+    MRGPDFKitDocumentRenderTypeFile
+};
+
 @interface MRGPDFKitDocument : NSObject
 
 @property (nonatomic) NSString *filename;
@@ -25,8 +31,8 @@
 
 - (BOOL)openDocument;
 - (void)closeDocument;
-- (UIImage *)imageFromPage:(NSUInteger)page width:(NSUInteger)width;
-- (NSData *)flattenedData;
+- (UIImage *)imageFromPage:(NSUInteger)page width:(NSUInteger)width renderType:(MRGPDFKitDocumentRenderType)renderType;
+- (NSData *)flattenedDataForRenderType:(MRGPDFKitDocumentRenderType)renderType;
 - (NSUInteger)getPageCount;
 
 - (NSArray *)fieldsWithType:(MRGPDFKitFieldType)type;

--- a/MRGPDFKit/Model/MRGPDFKitDocument.m
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.m
@@ -103,7 +103,7 @@
     }
 }
 
-- (NSData *)flattenedData
+- (NSData *)flattenedDataForRenderType:(MRGPDFKitDocumentRenderType)renderType
 {
     NSUInteger numberOfPages = [self getPageCount];
     NSMutableData *pageData = [NSMutableData data];
@@ -125,7 +125,9 @@
         CGContextRestoreGState(ctx);
 
         for(MRGPDFKitField *form in self.form) {
-            if(form.page == page) {
+
+            BOOL renderForm = (!form.isFieldNoView && renderType == MRGPDFKitDocumentRenderTypeView) || (!form.isFieldPrintable && renderType == MRGPDFKitDocumentRenderTypePrint) || renderType == MRGPDFKitDocumentRenderTypeFile;
+            if(form.page == page && renderForm) {
                 CGContextSaveGState(ctx);
                 CGRect frame = form.frame;
                 CGRect correctedFrame = CGRectMake(frame.origin.x-mediaRect.origin.x, mediaRect.size.height-frame.origin.y-frame.size.height-mediaRect.origin.y, frame.size.width, frame.size.height);
@@ -140,9 +142,9 @@
     return pageData;
 }
 
-- (UIImage *)imageFromPage:(NSUInteger)page width:(NSUInteger)width
+- (UIImage *)imageFromPage:(NSUInteger)page width:(NSUInteger)width renderType:(MRGPDFKitDocumentRenderType)renderType
 {
-    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)[self flattenedData]);
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)[self flattenedDataForRenderType:renderType]);
     CGPDFDocumentRef doc = CGPDFDocumentCreateWithProvider(dataProvider);
     CGDataProviderRelease(dataProvider);
 

--- a/MRGPDFKit/Model/MRGPDFKitField.h
+++ b/MRGPDFKit/Model/MRGPDFKitField.h
@@ -47,9 +47,27 @@ typedef NS_ENUM(NSUInteger, MRGPDFKitFieldType) {
 @property (nonatomic) NSString *setAppearanceStream;
 @property (nonatomic) MRGPDFKitDictionary *dictionary;
 @property (nonatomic) MRGPDFKitWidget *widget;
+@property (nonatomic) BOOL hidden;
 
 - (id)initWithFieldDictionary:(MRGPDFKitDictionary *)leaf page:(MRGPDFKitPage *)page parent:(MRGPDFKitForm *)parent;
 - (void)reset;
 - (void)vectorRenderInPDFContext:(CGContextRef)ctx forRect:(CGRect)rect;
 
+- (BOOL)isFieldReadOnly;
+- (BOOL)isFieldRequired;
+- (BOOL)isFieldNoExport;
+- (BOOL)isFieldNoToggleToOff;
+- (BOOL)isFieldRadio;
+- (BOOL)isFieldPushbutton;
+- (BOOL)isFieldCombo;
+- (BOOL)isFieldEdit;
+- (BOOL)isFieldSort;
+- (BOOL)isFieldMultiline;
+- (BOOL)isFieldPassword;
+- (BOOL)isFieldInvisible;
+- (BOOL)isFieldHidden;
+- (BOOL)isFieldPrintable;
+- (BOOL)isFieldNoZoom;
+- (BOOL)isFieldNoRotate;
+- (BOOL)isFieldNoView;
 @end

--- a/MRGPDFKit/Model/MRGPDFKitField.m
+++ b/MRGPDFKit/Model/MRGPDFKitField.m
@@ -211,6 +211,91 @@
     self.value = self.defaultValue;
 }
 
+- (BOOL)isFieldReadOnly
+{
+    return [self.flagsString rangeOfString:@"-ReadOnly"].location != NSNotFound;
+}
+
+- (BOOL)isFieldRequired
+{
+    return [self.flagsString rangeOfString:@"-Required"].location != NSNotFound;
+}
+
+- (BOOL)isFieldNoExport
+{
+    return [self.flagsString rangeOfString:@"-NoExport"].location != NSNotFound;
+}
+
+- (BOOL)isFieldNoToggleToOff
+{
+    return [self.flagsString rangeOfString:@"-NoToggleToOff"].location != NSNotFound;
+}
+
+- (BOOL)isFieldRadio
+{
+    return [self.flagsString rangeOfString:@"-Radio"].location != NSNotFound;
+}
+
+- (BOOL)isFieldPushbutton
+{
+    return [self.flagsString rangeOfString:@"-Pushbutton"].location != NSNotFound;
+}
+
+- (BOOL)isFieldCombo
+{
+    return [self.flagsString rangeOfString:@"-Combo"].location != NSNotFound;
+}
+
+- (BOOL)isFieldEdit
+{
+    return [self.flagsString rangeOfString:@"-Edit"].location != NSNotFound;
+}
+
+- (BOOL)isFieldSort
+{
+    return [self.flagsString rangeOfString:@"-Sort"].location != NSNotFound;
+}
+
+- (BOOL)isFieldMultiline
+{
+    return [self.flagsString rangeOfString:@"-Multiline"].location != NSNotFound;
+}
+
+- (BOOL)isFieldPassword
+{
+    return [self.flagsString rangeOfString:@"-Password"].location != NSNotFound;
+}
+
+- (BOOL)isFieldInvisible
+{
+    return [self.flagsString rangeOfString:@"-Invisible"].location != NSNotFound;
+}
+
+- (BOOL)isFieldHidden
+{
+    return [self.flagsString rangeOfString:@"-Hidden"].location != NSNotFound;
+}
+
+- (BOOL)isFieldPrintable
+{
+    return [self.flagsString rangeOfString:@"-Print"].location != NSNotFound;
+}
+
+- (BOOL)isFieldNoZoom
+{
+    return [self.flagsString rangeOfString:@"-NoZoom"].location != NSNotFound;
+}
+
+- (BOOL)isFieldNoRotate
+{
+    return [self.flagsString rangeOfString:@"-NoRotate"].location != NSNotFound;
+}
+
+- (BOOL)isFieldNoView
+{
+    return [self.flagsString rangeOfString:@"-NoView"].location != NSNotFound;
+}
+
 //------------------------------------------------------------------------------
 #pragma mark - Private
 //------------------------------------------------------------------------------

--- a/MRGPDFKit/View/MRGPDFKitImageView.m
+++ b/MRGPDFKit/View/MRGPDFKitImageView.m
@@ -35,7 +35,7 @@
 
 - (void)displayPage:(NSInteger)page
 {
-    self.pdfView.image = [self.nativeDocument imageFromPage:page width:self.bounds.size.width];
+    self.pdfView.image = [self.nativeDocument imageFromPage:page width:self.bounds.size.width renderType:MRGPDFKitDocumentRenderTypeView];
 }
 
 @end


### PR DESCRIPTION
Ajout du support du type de rendu pour permettre la gestion des champs cachés pour un type de rendu en particulier (ex.: invisible à la visualisation, mais visible à l'impression).

Ajout de méthodes utilitaires pour savoir si un _field_ possède une caractéristique en particulier (permet d'abstraire les valeurs d'identification des _flags_ contenues dans le fichier PDF brut)
