### PR TITLE
Add support for initializing a PDFKitDocument with NSData.

### DIFF
--- a/MRGPDFKit/Model/MRGPDFKitDocument.h
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.h
@@ -28,6 +28,7 @@ typedef NS_ENUM(NSUInteger, MRGPDFKitDocumentRenderType) {
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 - (instancetype)initWithFileName:(NSString *)filename;
+- (instancetype)initWithDocumentData:(NSData *)documentData;
 
 - (BOOL)openDocument;
 - (void)closeDocument;

--- a/MRGPDFKit/Model/MRGPDFKitDocument.m
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.m
@@ -160,7 +160,7 @@
     return pageData;
 }
 
-- (NSData *)flattenedDataWithAnnotations:(NSArray *)annotations flattenedDataForRenderType:(MRGPDFKitDocumentRenderType)renderType {
+- (NSData *)flattenedDataWithAnnotations:(NSArray *)annotations renderType:(MRGPDFKitDocumentRenderType)renderType {
     return [self flattenedDataWithURL:nil annotations:annotations renderType:renderType];
 }
 

--- a/MRGPDFKit/Model/MRGPDFKitDocument.m
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.m
@@ -28,6 +28,18 @@
     return self;
 }
 
+- (instancetype)initWithDocumentData:(NSData *)documentData {
+    self = [super init];
+    if (self) {
+        _documentData = documentData;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [self closeDocument];
+}
+
 // -----------------------------------------------------------------------------
 #pragma mark - Getter
 // -----------------------------------------------------------------------------
@@ -91,8 +103,14 @@
 - (BOOL)openDocument
 {
     [self closeDocument];
-    _document = [MRGPDFKitUtility newPDFDocumentRefFromPath:self.filename];
-    return YES;
+    
+    if (_documentData != nil) {
+        _document = [MRGPDFKitUtility newPDFDocumentRefFromData:_documentData];
+    } else if (_filename != nil) {
+        _document = [MRGPDFKitUtility newPDFDocumentRefFromPath:self.filename];
+    }
+    
+    return _document != nil;
 }
 
 - (void)closeDocument


### PR DESCRIPTION
Add support for initializing a PDFKitDocument with NSData.

**Also**
* Automatically call CGPDFDocumentRelease upon dealloc.
* openDocument() will return FALSE if CGPDFDocumentRef cannot be created.