### PR TITLE
Fix a case where the wrong type was assigned to documentData

### DIFF
--- a/MRGPDFKit/Model/MRGPDFKitArray.m
+++ b/MRGPDFKit/Model/MRGPDFKitArray.m
@@ -76,7 +76,7 @@
     y0 = [[self.nsa objectAtIndex:1] floatValue];
     x1 = [[self.nsa objectAtIndex:2] floatValue];
     y1 = [[self.nsa objectAtIndex:3] floatValue];
-    return CGRectMake(MIN(x0,x1),MIN(y0,y1),fabsf(x1-x0),fabsf(y1-y0));
+    return CGRectMake(MIN(x0,x1),MIN(y0,y1),fabsf((float)(x1-x0)),fabsf((float)(y1-y0)));
 }
 
 - (id)objectAtIndex:(NSUInteger)index

--- a/MRGPDFKit/Model/MRGPDFKitDocument.m
+++ b/MRGPDFKit/Model/MRGPDFKitDocument.m
@@ -31,7 +31,7 @@
 - (instancetype)initWithDocumentData:(NSData *)documentData {
     self = [super init];
     if (self) {
-        _documentData = documentData;
+        _documentData = [[NSMutableData alloc] initWithData:documentData];
     }
     return self;
 }

--- a/MRGPDFKit/Model/MRGPDFKitForm.m
+++ b/MRGPDFKit/Model/MRGPDFKitForm.m
@@ -100,7 +100,7 @@
     NSUInteger targ = (NSUInteger)(((MRGPDFKitDictionary *)[leaf objectForKey:@"P"]).dictionary);
     leaf.parent = parent;
     
-    if (targ == nil) return;
+    if (targ == 0) return;
     
     id pdfPageIndexValue = [pmap objectForKey:[NSNumber numberWithUnsignedInteger:targ]];
     if (pdfPageIndexValue) {


### PR DESCRIPTION
Fix a case where the wrong type was assigned to documentData (XCode only gave a warning for that).

Also:
- Fix some warnings that were reported by Xcode 8.3