### PR TITLE
Update MCUIViewLayout version dependency to remove warnings.

### DIFF
--- a/MRGPDFKit.podspec
+++ b/MRGPDFKit.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'MCUIViewLayout', '0.3.4'
+  s.dependency 'MCUIViewLayout', '~> 0.5.1'
 end


### PR DESCRIPTION
Quelqu'un voit un inconvénient à utiliser la dernière version de MCUIViewLayout? Ça fix un warning dans MCUIViewLayout qui apparaissait toujours depuis un bout.